### PR TITLE
Task/test let keyword

### DIFF
--- a/.idea/fantasy-unicorn-ruby.iml
+++ b/.idea/fantasy-unicorn-ruby.iml
@@ -48,6 +48,7 @@
     <orderEntry type="library" scope="PROVIDED" name="concurrent-ruby (v1.1.9, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="crass (v1.0.6, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="diff-lcs (v1.4.4, rbenv: 3.0.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="docile (v1.4.0, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="erubi (v1.10.0, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="factory_bot (v6.2.0, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="factory_bot_rails (v6.2.0, rbenv: 3.0.2) [gem]" level="application" />
@@ -91,6 +92,9 @@
     <orderEntry type="library" scope="PROVIDED" name="rubocop (v1.22.3, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="rubocop-ast (v1.12.0, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="ruby-progressbar (v1.11.0, rbenv: 3.0.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov (v0.21.2, rbenv: 3.0.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov-html (v0.12.3, rbenv: 3.0.2) [gem]" level="application" />
+    <orderEntry type="library" scope="PROVIDED" name="simplecov_json_formatter (v0.1.3, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="spring (v3.0.0, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="sprockets (v4.0.2, rbenv: 3.0.2) [gem]" level="application" />
     <orderEntry type="library" scope="PROVIDED" name="sprockets-rails (v3.2.2, rbenv: 3.0.2) [gem]" level="application" />

--- a/spec/models/achievement_spec.rb
+++ b/spec/models/achievement_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe Achievement, type: :model do
   end
 
   it 'destroyed together with the user' do
-    expect { user.destroy }.to change(subject, :exists).to(false)
+    expect { user.destroy }.to change { Achievement.exists?(id: subject.id) }.to(false)
   end
 
   it "doesn't destroy owner on destroy" do
-    expect { achievement.destroy }.not_to change(user, :exists).to(false)
+    expect { subject.destroy }.not_to(change { User.exists?(id: user.id) })
   end
 end

--- a/spec/models/achievement_spec.rb
+++ b/spec/models/achievement_spec.rb
@@ -3,48 +3,42 @@
 require 'rails_helper'
 
 RSpec.describe Achievement, type: :model do
-  it 'valid with valid arguments' do
-    expect(create(:achievement)).to be_valid
+  subject { create :achievement }
+  let(:user) { subject.user }
+  let(:achievement_identifier) { subject.achievement_identifier }
+  let(:id) { subject.id }
+
+  it 'is valid with valid arguments' do
+    is_expected.to be_valid
   end
 
   it "isn't valid without user id" do
-    expect do
-      create :achievement, user_id: nil
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.user = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid without achievement identifier" do
-    expect do
-      create :achievement, achievement_identifier: nil
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.achievement_identifier = nil
+    is_expected.to_not be_valid
   end
 
-  context 'created with default parameters' do
-    before do
-      @achievement = create :achievement
-      @user = @achievement.user
-    end
+  it 'must have unique achievement identifier per user' do
+    expect do
+      create :achievement, user: user, achievement_identifier: achievement_identifier
+    end.to raise_error(ActiveRecord::RecordNotUnique)
+  end
 
-    it 'must have unique achievement identifier per user' do
-      expect do
-        create :achievement, user: @achievement.user, achievement_identifier: @achievement.achievement_identifier
-      end.to raise_error(ActiveRecord::RecordNotUnique)
-    end
+  it 'can share achievement identifier with other users' do
+    expect do
+      create :achievement, achievement_identifier: achievement_identifier
+    end.to_not raise_error
+  end
 
-    it 'can share achievement identifier with other users' do
-      expect do
-        create :achievement, achievement_identifier: @achievement.achievement_identifier
-      end.to_not raise_error
-    end
+  it 'destroyed together with the user' do
+    expect { user.destroy }.to change(subject, :exists).to(false)
+  end
 
-    it 'destroyed together with the user' do
-      @user.destroy
-      expect(Achievement.where(id: @achievement.id)).to_not be_present
-    end
-
-    it "doesn't destroy owner on destroy" do
-      @achievement.destroy
-      expect(User.where(id: @user.id)).to be_present
-    end
+  it "doesn't destroy owner on destroy" do
+    expect { achievement.destroy }.not_to change(user, :exists).to(false)
   end
 end

--- a/spec/models/briefcase_spec.rb
+++ b/spec/models/briefcase_spec.rb
@@ -3,22 +3,20 @@
 require 'rails_helper'
 
 RSpec.describe Briefcase, type: :model do
-  context 'created with defaults' do
-    subject { create(:briefcase) }
+  subject { create(:briefcase) }
 
-    it 'is valid' do
-      is_expected.to be_valid
-    end
+  it 'is valid' do
+    is_expected.to be_valid
+  end
 
-    it "isn't valid without user" do
-      subject.user_id = nil
-      is_expected.to_not be_valid
-    end
+  it "isn't valid without user" do
+    subject.user_id = nil
+    is_expected.to_not be_valid
+  end
 
-    it "isn't valid without expired" do
-      subject.expiring_at = nil
-      is_expected.to_not be_valid
-    end
+  it "isn't valid without expired" do
+    subject.expiring_at = nil
+    is_expected.to_not be_valid
   end
 
   context 'created with stocks' do
@@ -63,56 +61,4 @@ RSpec.describe Briefcase, type: :model do
       end
     end
   end
-  # it 'is valid with valid parameters' do
-  #   expect(create(:briefcase)).to be_valid
-  # end
-  #
-  # it 'is valid with stocks' do
-  #   expect(create(:briefcase, :with_stocks)).to be_valid
-  # end
-  #
-  # it "isn't valid without user" do
-  #   expect { create :briefcase, user_id: nil }.to raise_error(ActiveRecord::RecordInvalid)
-  # end
-  #
-  # it "isn't valid without expired" do
-  #   expect { create :briefcase, expiring_at: nil }.to raise_error(ActiveRecord::RecordInvalid)
-  # end
-  #
-  # it "isn't valid if stocks count exceeds maximum" do
-  #   stocks_count = Briefcase::BRIEFCASE_STOCKS_MAX_COUNT + 1
-  #   expect { create :briefcase, :with_stocks, stock_count: stocks_count }.to raise_error(ActiveRecord::RecordInvalid)
-  # end
-  #
-  # context 'created with default parameters' do
-  #   before do
-  #     @briefcase = create :briefcase, :with_stocks
-  #     @user = @briefcase.user
-  #     @stocks = @briefcase.stocks
-  #   end
-  #
-  #   it 'must be unique per user' do
-  #     expect { create :briefcase, user: @user }.to raise_error(ActiveRecord::RecordNotUnique)
-  #   end
-  #
-  #   it 'is destroyed along with the user' do
-  #     expect { @user.destroy }.to change { Briefcase.exists?(id: @briefcase.id) }.from(true).to(false)
-  #   end
-  #
-  #   it "isn't destroy along with the stock" do
-  #     expect { @stocks.sample.destroy }.not_to change { Briefcase.exists?(id: @briefcase.id) }.from(true)
-  #   end
-  #
-  #   it "isn't destroy the owner when called destroy" do
-  #     expect { @briefcase.destroy }.not_to change { User.exists?(id: @user.id) }.from(true)
-  #   end
-  #
-  #   it "isn't destroy the stocks when called destroy" do
-  #     expect { @briefcase.destroy }.not_to change(Stock, :count)
-  #   end
-  #
-  #   it "can't have the same stock twice" do
-  #     expect { @briefcase.stocks.append(@stocks.sample) }.to raise_error(ActiveRecord::RecordNotUnique)
-  #   end
-  # end
 end

--- a/spec/models/briefcase_spec.rb
+++ b/spec/models/briefcase_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Briefcase, type: :model do
   subject { create(:briefcase) }
 
-  it 'is valid' do
+  it 'is valid with valid arguments' do
     is_expected.to be_valid
   end
 

--- a/spec/models/briefcase_spec.rb
+++ b/spec/models/briefcase_spec.rb
@@ -3,56 +3,116 @@
 require 'rails_helper'
 
 RSpec.describe Briefcase, type: :model do
-  it 'is valid with valid parameters' do
-    expect(create(:briefcase)).to be_valid
+  context 'created with defaults' do
+    subject { create(:briefcase) }
+
+    it 'is valid' do
+      is_expected.to be_valid
+    end
+
+    it "isn't valid without user" do
+      subject.user_id = nil
+      is_expected.to_not be_valid
+    end
+
+    it "isn't valid without expired" do
+      subject.expiring_at = nil
+      is_expected.to_not be_valid
+    end
   end
 
-  it 'is valid with stocks' do
-    expect(create(:briefcase, :with_stocks)).to be_valid
-  end
+  context 'created with stocks' do
+    subject { create(:briefcase, :with_stocks) }
+    let(:stocks) { subject.stocks }
+    let(:user) { subject.user }
 
-  it "isn't valid without user" do
-    expect { create :briefcase, user_id: nil }.to raise_error(ActiveRecord::RecordInvalid)
-  end
-
-  it "isn't valid without expired" do
-    expect { create :briefcase, expiring_at: nil }.to raise_error(ActiveRecord::RecordInvalid)
-  end
-
-  it "isn't valid if stocks count exceeds maximum" do
-    stocks_count = Briefcase::BRIEFCASE_STOCKS_MAX_COUNT + 1
-    expect { create :briefcase, :with_stocks, stock_count: stocks_count }.to raise_error(ActiveRecord::RecordInvalid)
-  end
-
-  context 'created with default parameters' do
-    before do
-      @briefcase = create :briefcase, :with_stocks
-      @user = @briefcase.user
-      @stocks = @briefcase.stocks
+    it 'is valid' do
+      is_expected.to be_valid
     end
 
     it 'must be unique per user' do
-      expect { create :briefcase, user: @user }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect { create :briefcase, user: user }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it 'is destroyed along with the user' do
-      expect { @user.destroy }.to change { Briefcase.exists?(id: @briefcase.id) }.from(true).to(false)
+      expect { user.destroy }.to change { Briefcase.exists?(id: subject.id) }.from(true).to(false)
     end
 
     it "isn't destroy along with the stock" do
-      expect { @stocks.sample.destroy }.not_to change { Briefcase.exists?(id: @briefcase.id) }.from(true)
+      expect { stocks.sample.destroy }.not_to change { Briefcase.exists?(id: subject.id) }.from(true)
     end
 
     it "isn't destroy the owner when called destroy" do
-      expect { @briefcase.destroy }.not_to change { User.exists?(id: @user.id) }.from(true)
+      expect { subject.destroy }.not_to change { User.exists?(id: user.id) }.from(true)
     end
 
     it "isn't destroy the stocks when called destroy" do
-      expect { @briefcase.destroy }.not_to change(Stock, :count)
+      expect { subject.destroy }.not_to change(Stock, :count).from(stocks.size)
     end
 
     it "can't have the same stock twice" do
-      expect { @briefcase.stocks.append(@stocks.sample) }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect { subject.stocks.append(stocks.sample) }.to raise_error(ActiveRecord::RecordNotUnique)
+    end
+
+    context 'and with too many stocks' do
+      subject { build(:briefcase, :with_stocks, stock_count: stock_count) }
+      let(:stock_count) { Briefcase::BRIEFCASE_STOCKS_MAX_COUNT + 1 }
+
+      it "isn't valid" do
+        is_expected.to_not be_valid
+      end
     end
   end
+  # it 'is valid with valid parameters' do
+  #   expect(create(:briefcase)).to be_valid
+  # end
+  #
+  # it 'is valid with stocks' do
+  #   expect(create(:briefcase, :with_stocks)).to be_valid
+  # end
+  #
+  # it "isn't valid without user" do
+  #   expect { create :briefcase, user_id: nil }.to raise_error(ActiveRecord::RecordInvalid)
+  # end
+  #
+  # it "isn't valid without expired" do
+  #   expect { create :briefcase, expiring_at: nil }.to raise_error(ActiveRecord::RecordInvalid)
+  # end
+  #
+  # it "isn't valid if stocks count exceeds maximum" do
+  #   stocks_count = Briefcase::BRIEFCASE_STOCKS_MAX_COUNT + 1
+  #   expect { create :briefcase, :with_stocks, stock_count: stocks_count }.to raise_error(ActiveRecord::RecordInvalid)
+  # end
+  #
+  # context 'created with default parameters' do
+  #   before do
+  #     @briefcase = create :briefcase, :with_stocks
+  #     @user = @briefcase.user
+  #     @stocks = @briefcase.stocks
+  #   end
+  #
+  #   it 'must be unique per user' do
+  #     expect { create :briefcase, user: @user }.to raise_error(ActiveRecord::RecordNotUnique)
+  #   end
+  #
+  #   it 'is destroyed along with the user' do
+  #     expect { @user.destroy }.to change { Briefcase.exists?(id: @briefcase.id) }.from(true).to(false)
+  #   end
+  #
+  #   it "isn't destroy along with the stock" do
+  #     expect { @stocks.sample.destroy }.not_to change { Briefcase.exists?(id: @briefcase.id) }.from(true)
+  #   end
+  #
+  #   it "isn't destroy the owner when called destroy" do
+  #     expect { @briefcase.destroy }.not_to change { User.exists?(id: @user.id) }.from(true)
+  #   end
+  #
+  #   it "isn't destroy the stocks when called destroy" do
+  #     expect { @briefcase.destroy }.not_to change(Stock, :count)
+  #   end
+  #
+  #   it "can't have the same stock twice" do
+  #     expect { @briefcase.stocks.append(@stocks.sample) }.to raise_error(ActiveRecord::RecordNotUnique)
+  #   end
+  # end
 end

--- a/spec/models/contest_application_spec.rb
+++ b/spec/models/contest_application_spec.rb
@@ -20,11 +20,11 @@ RSpec.describe ContestApplication, type: :model do
   end
 
   it "isn't destroy the user" do
-    expect { subject.destroy }.not_to(change { User.exists?(id: user.id) })
+    expect { subject.destroy }.not_to change { User.exists?(id: user.id) }.from(true)
   end
 
   it "isn't destroy the contest" do
-    expect { subject.destroy }.not_to(change { Contest.exists?(id: contest.id) })
+    expect { subject.destroy }.not_to change { Contest.exists?(id: contest.id) }.from(true)
   end
 
   it "can't duplicate contest-user pair" do

--- a/spec/models/contest_application_spec.rb
+++ b/spec/models/contest_application_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe ContestApplication, type: :model do
     expect { contest.status = Contest.statuses[:finished] }.to change(subject, :valid?).from(true).to(false)
   end
 
-  context 'with finish data' do
+  context 'created with finish data' do
     subject { create :contest_application, :with_results }
     let(:final_position) { subject.final_position }
 

--- a/spec/models/contest_application_spec.rb
+++ b/spec/models/contest_application_spec.rb
@@ -3,70 +3,63 @@
 require 'rails_helper'
 
 RSpec.describe ContestApplication, type: :model do
-  context 'with minimum attributes' do
-    before do
-      @application = create :contest_application
-      @user = @application.user
-      @contest = @application.contest
-    end
+  subject { create :contest_application }
+  let(:user) { subject.user }
+  let(:contest) { subject.contest }
 
-    it 'is valid' do
-      expect(@application).to be_valid
-    end
+  it 'is valid' do
+    is_expected.to be_valid
+  end
 
-    it 'is destroyed together with the user' do
-      expect { @user.destroy }.to change(ContestApplication, :count).from(1).to(0)
-    end
+  it 'is destroyed together with the user' do
+    expect { user.destroy }.to change { ContestApplication.exists?(id: subject.id) }.from(true)
+  end
 
-    it 'is destroyed together with the contest' do
-      expect { @application.destroy }.to change(ContestApplication, :count).from(1).to(0)
-    end
+  it 'is destroyed together with the contest' do
+    expect { subject.destroy }.to change { ContestApplication.exists?(id: subject.id) }.from(true)
+  end
 
-    it "isn't destroy the user" do
-      expect { @application.destroy }.not_to change(User, :count).from(1)
-    end
+  it "isn't destroy the user" do
+    expect { subject.destroy }.not_to(change { User.exists?(id: user.id) })
+  end
 
-    it "isn't destroy the contest" do
-      expect { @application.destroy }.not_to change(Contest, :count).from(1)
-    end
+  it "isn't destroy the contest" do
+    expect { subject.destroy }.not_to(change { Contest.exists?(id: contest.id) })
+  end
 
-    it "can't duplicate contest-user pair" do
-      expect do
-        create :contest_application, contest: @contest, user: @user
-      end.to raise_error(ActiveRecord::RecordNotUnique)
-    end
+  it "can't duplicate contest-user pair" do
+    expect do
+      create :contest_application, contest: contest, user: user
+    end.to raise_error(ActiveRecord::RecordNotUnique)
+  end
 
-    it "isn't valid if contest status == finished" do
-      expect { @contest.status = Contest.statuses[:finished] }.to change(@application, :valid?).from(true).to(false)
-    end
+  it "isn't valid if contest status == finished" do
+    expect { contest.status = Contest.statuses[:finished] }.to change(subject, :valid?).from(true).to(false)
   end
 
   context 'with finish data' do
-    before do
-      @application = create :contest_application, :with_results
-      @user = @application.user
-      @contest = @application.contest
-    end
+    subject { create :contest_application, :with_results }
+    let(:final_position) { subject.final_position }
 
     it 'is valid' do
-      expect(@application).to be_valid
+      is_expected.to be_valid
     end
 
     it "isn't valid if contest status != finished" do
-      expect { @contest.status = Contest.statuses[:created] }.to change(@application, :valid?).from(true).to(false)
+      expect { contest.status = Contest.statuses[:created] }.to change(subject, :valid?).from(true).to(false)
     end
 
     it "can't share position within the same contest" do
       expect do
         create :contest_application, :with_results,
-               user: @user, contest: @contest, final_position: @application.final_position
+               user: user, contest: contest, final_position: final_position
       end.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it 'can share position on separate contests' do
       expect(
         create(:contest_application, :with_results,
-               user: @user, final_position: @application.final_position)
+               user: user, final_position: final_position)
       ).to be_valid
     end
   end

--- a/spec/models/contest_application_spec.rb
+++ b/spec/models/contest_application_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ContestApplication, type: :model do
   let(:user) { subject.user }
   let(:contest) { subject.contest }
 
-  it 'is valid' do
+  it 'is valid with valid arguments' do
     is_expected.to be_valid
   end
 

--- a/spec/models/contest_spec.rb
+++ b/spec/models/contest_spec.rb
@@ -3,120 +3,130 @@
 require 'rails_helper'
 
 RSpec.describe Contest, type: :model do
-  it 'is valid with bare minimum attributes' do
-    expect(create(:contest)).to be_valid
+  subject { create(:contest) }
+
+  it 'is valid with valid arguments' do
+    is_expected.to be_valid
   end
 
-  context 'with preconfigured stocks' do
-    before do
-      @contest = create :contest, :with_stocks
-      @stocks = @contest.stocks
-    end
+  context 'created with preconfigured stocks' do
+    subject { create(:contest, :with_stocks) }
+    let(:stocks) { subject.stocks }
 
     it 'is valid' do
-      expect(@contest).to be_valid
+      is_expected.to be_valid
     end
 
     it "can't have the same stock twice" do
-      expect { @contest.stocks << @stocks.sample }.to raise_error(ActiveRecord::RecordNotUnique)
+      expect { subject.stocks << stocks.sample }.to raise_error(ActiveRecord::RecordNotUnique)
     end
 
     it "doesn't destroy stock on destroy" do
-      expect { @contest.destroy }.not_to change(Stock, :count)
+      expect { subject.destroy }.not_to change(Stock, :count).from(stocks.size)
     end
 
     it "doesn't destroy on destroy stock" do
-      expect { @stocks.sample.destroy }.not_to change(Contest, :count)
+      expect { stocks.sample.destroy }.not_to change { Contest.exists?(id: subject.id) }.from(true)
     end
   end
 
-  context 'with registered users' do
-    before do
-      @contest = create(:contest, :with_participants)
-      @applications = @contest.contest_applications
-    end
+  context 'created with registered users' do
+    subject { create(:contest, :with_participants) }
+    let(:applications) { subject.contest_applications }
 
     it 'is valid' do
-      expect(@contest).to be_valid
+      is_expected.to be_valid
     end
 
     it "isn't valid if status changed to finished" do
-      expect { @contest.status = Contest.statuses[:finished] }.to change(@contest, :valid?).to(false)
+      expect { subject.status = Contest.statuses[:finished] }.to change(subject, :valid?).to(false)
     end
 
-    it 'can be transformed to finished' do
-      expect do
-        Contest.transaction do
-          @contest.status = Contest.statuses[:finished]
-          i = 1
-          @applications.each do |application|
-            application.final_position = i
-            i += 1
-            application.coins_delta = 1
-            application.fantasy_points_delta = 1
-            application.save!
-          end
-          @contest.save!
+    context 'transformable to finished' do
+      before { transform }
+
+      def transform
+        subject.status = Contest.statuses[:finished]
+        i = 1
+        applications.each do |application|
+          application.final_position = i
+          i += 1
+          application.coins_delta = 1
+          application.fantasy_points_delta = 1
+          application.save!
         end
-      end.to_not raise_error
-      expect(@contest).to be_valid
-      @applications.each { |a| expect(a).to be_valid }
+        subject.save!
+      end
+
+      it 'and contest would be still valid' do
+        is_expected.to be_valid
+      end
+
+      it 'and all stocks are valid' do
+        applications.each { |a| expect(a).to be_valid }
+      end
     end
   end
 
-  it 'is valid with registered users and preconfigured stocks' do
-    expect(create(:contest, :with_participants, :with_stocks)).to be_valid
+  context 'created with registered users and preconfigured stocks' do
+    subject { create(:contest, :with_participants, :with_stocks) }
+
+    it 'is valid' do
+      is_expected.to be_valid
+    end
   end
 
   it "isn't valid without reg ending timestamp" do
-    expect { create :contest, reg_ending_at: nil }.to raise_error(ActiveRecord::RecordInvalid)
+    subject.reg_ending_at = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid without summarizing timestamp" do
-    expect { create :contest, summarizing_at: nil }.to raise_error(ActiveRecord::RecordInvalid)
+    subject.summarizing_at = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid with negative coins entry fee" do
-    expect { create :contest, coins_entry_fee: -Faker::Number.number.abs }.to raise_error(ActiveRecord::RecordInvalid)
+    subject.coins_entry_fee = -Faker::Number.number.abs
+    is_expected.to_not be_valid
   end
 
   it "isn't valid with negative max fantasy points threshold" do
-    expect do
-      create :contest, max_fantasy_points_threshold: -Faker::Number.number.abs
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.max_fantasy_points_threshold = -Faker::Number.number.abs
+    is_expected.to_not be_valid
   end
 
   it "isn't valid without direction strategy" do
-    expect { create :contest, direction_strategy: nil }.to raise_error(ActiveRecord::RecordInvalid)
+    subject.direction_strategy = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid without status" do
-    expect { create :contest, status: nil }.to raise_error(ActiveRecord::RecordInvalid)
+    subject.status = nil
+    is_expected.to_not be_valid
   end
 
   it "can't have fixed direction up if direction strategy isn't 'fixed'" do
-    expect do
-      create :contest, direction_strategy: Contest.direction_strategies[:free], fixed_direction_up: false
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.direction_strategy = Contest.direction_strategies[:free]
+    subject.fixed_direction_up = false
+    is_expected.to_not be_valid
   end
 
   it "can have fixed direction up if direction strategy is 'fixed'" do
-    direction_strategy = Contest.direction_strategies[:fixed]
-    expect(create(:contest, direction_strategy: direction_strategy, fixed_direction_up: false)).to be_valid
+    subject.direction_strategy = Contest.direction_strategies[:fixed]
+    subject.fixed_direction_up = false
+    is_expected.to be_valid
   end
 
   context 'finished and with users' do
-    before do
-      @contest = create :contest, :with_participants, :finished
-      @applications = @contest.contest_applications
-    end
+    subject { create(:contest, :with_participants, :finished) }
+    let(:applications) { subject.contest_applications }
 
     it 'is valid' do
-      expect(@contest).to be_valid
+      is_expected.to be_valid
     end
-
     it "can't return status back" do
-      expect { @contest.status = Contest.statuses[:created] }.to change(@contest, :valid?).to(false)
+      expect { subject.status = Contest.statuses[:created] }.to change(subject, :valid?).to(false)
     end
   end
 end

--- a/spec/models/stock_spec.rb
+++ b/spec/models/stock_spec.rb
@@ -3,38 +3,36 @@
 require 'rails_helper'
 
 RSpec.describe Stock, type: :model do
-  it 'valid with valid arguments' do
-    expect(create(:stock)).to be_valid
+  subject { create(:stock) }
+  let(:name) { subject.name }
+
+  it 'is valid with valid arguments' do
+    is_expected.to be_valid
   end
 
   it "isn't valid without name" do
-    expect do
-      create :stock, name: nil
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.name = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid without robinhood id" do
-    expect do
-      create :stock, robinhood_id: nil
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.robinhood_id = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid if name is too long" do
-    expect do
-      create :stock, name: Faker::String.random(length: 40)
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.name = Faker::String.random(length: 40)
+    is_expected.to_not be_valid
   end
 
   it "isn't valid if robinhood id isn't UUID" do
-    expect do
-      create :stock, robinhood_id: Faker::String.random(length: 35)
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.robinhood_id = Faker::String.random(length: 35)
+    is_expected.to_not be_valid
   end
 
   it 'must have unique name' do
-    s = create :stock
     expect do
-      create :stock, name: s.name
+      create :stock, name: name
     end.to raise_error(ActiveRecord::RecordNotUnique)
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,77 +3,71 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it 'valid with valid attributes' do
-    expect(create(:user_with_points)).to be_valid
-  end
+  subject { create(:user) }
+  let(:username) { subject.username }
+  let(:email) { subject.email }
 
-  it 'valid with only necessary attributes' do
-    expect(create(:user)).to be_valid
+  it 'is valid with valid arguments' do
+    is_expected.to be_valid
   end
 
   it "isn't valid without username" do
-    expect do
-      create :user, username: nil
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.username = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid without email" do
-    expect do
-      create :user, email: nil
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.email = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid without password" do
-    expect do
-      create :user, password: nil
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.password = nil
+    is_expected.to_not be_valid
   end
 
   it "isn't valid if username is too big" do
-    expect do
-      create :user, username: Faker::Internet.username(specifier: 30..40)
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.username = Faker::Internet.username(specifier: 30..40)
+    is_expected.to_not be_valid
   end
 
   it "isn't valid if password is too big" do
-    expect do
-      create :user, password: Faker::Internet.password(min_length: 300)
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.username = Faker::Internet.password(min_length: 300)
+    is_expected.to_not be_valid
   end
 
   it "isn't valid if preferred lang is too big" do
-    expect do
-      create :user, preferred_lang: Faker::String.random(length: 15)
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.preferred_lang = Faker::String.random(length: 15)
+    is_expected.to_not be_valid
   end
 
   it "isn't valid if coins are below zero" do
-    expect do
-      create :user, coins: -Faker::Number.number.abs
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.coins = -Faker::Number.number.abs
+    is_expected.to_not be_valid
   end
 
   it "isn't valid if fantasy points are below zero" do
-    expect do
-      create :user, fantasy_points: -Faker::Number.number.abs
-    end.to raise_error(ActiveRecord::RecordInvalid)
+    subject.fantasy_points = -Faker::Number.number.abs
+    is_expected.to_not be_valid
   end
 
-  context 'created with default parametes' do
-    before do
-      @user = create :user
-    end
+  it 'must have unique username' do
+    expect do
+      create :user, username: username
+    end.to raise_error(ActiveRecord::RecordNotUnique)
+  end
 
-    it 'must have unique username' do
-      expect do
-        create :user, username: @user.username
-      end.to raise_error(ActiveRecord::RecordNotUnique)
-    end
+  it 'must have unique email' do
+    expect do
+      create :user, email: email
+    end.to raise_error(ActiveRecord::RecordNotUnique)
+  end
 
-    it 'must have unique email' do
-      expect do
-        create :user, email: @user.email
-      end.to raise_error(ActiveRecord::RecordNotUnique)
+  context 'created with points' do
+    subject { create(:user_with_points) }
+
+    it 'is valid' do
+      is_expected.to be_valid
     end
   end
 end


### PR DESCRIPTION
Данный PR рефакторит существующие тесты и вводит subject/let вместо before.  
let предложен @igor-alexandrov, subject всплыл в процессе поиска темы. Также некоторые конструкции были приведены к единому виду.

## let
let - lazy initialization конструкция, инициализирующая переменную только тогда, когда она впервые вызывается.  
Также let также делает проще создание вложенных контекстов (`context`). Он позволяет переопределять переменные так, что зависимые от них переменные поменяются вслед за переопределенными.

Например, вместо такого:
```ruby
before do
  @drink = create :drink
  @id = @drink.id
  @bar = @drink.bar
end

context 'created as vodka' do
  before do
    @drink = create :drink, :vodka
    @id = @drink.id
    @bar = @drink.bar
  end
  
  context 'with orders' do
    before do
      @drink = create :drink, :vodka, :with_orders
      @orders = @drink.orders
      @id = @drink.id
      @bar = @drink.bar
    end
  end
end
```
Можно сделать так:
```ruby
let(:drink) { create :drink }
let(:id) { drink.id }

context 'created as vodka' do
  let(:drink) { create :drink, :vodka }
  
  context 'with orders' do
    let(:drink) { create :drink, :vodka, :with_orders }
    let(:orders) { drink.orders }
  end
end
```
Или даже так:
```ruby
let(:drink) { create :drink }
let(:id) { drink.id }
let(:orders) { drink.orders }

context 'created as vodka' do
  let(:drink) { create :drink, :vodka }
  
  context 'with orders' do
    let(:drink) { create :drink, :vodka, :with_orders }
  end
end
```
Таким образом, достигается сразу три эффекта:
1. Меньше писать кода
2. Лишний код не вызывается, когда не нужен. Например, если тест не использует переменные id или orders, то соответствующие блоки кода не вызываются вовсе. В изначальном примере-же все тесты в контексте 'created as vodka with orders' вызывают все три before-блока, что грустно :(
3. Код немного чище

## subject
subject - идейно работает как `let(:subject)`, однако также вносит дополнительную конструкцию `is_expected`, работающую как `expect(subject)`. Она выглядит чуть симпатичнее имхо :)

Например, вместо такого:
```ruby
let(:drink) { create :drink }

it 'is valid' do
  expect(drink).to be_valid
end
```
Можно писать так:
```ruby
subject { create :drink }
it 'is valid' do
  is_expected.to be_valid
end
```