### PR TITLE
Feature/change, remebmer password

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,7 +67,7 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
 
-  config.action_mailer.default_url_options = { host: 'https://fantasy-unic-feature-co-bzuptq.herokuapp.com' }
+  config.action_mailer.default_url_options = { host: 'https://fantasy-unicorn-ruby-prod.herokuapp.com' }
   config.action_mailer.smtp_settings = {
     user_name: Rails.application.credentials.email,
     password: Rails.application.credentials.email_password,

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -59,4 +59,5 @@ DeviseTokenAuth.setup do |config|
   config.send_confirmation_email = true
   config.require_client_password_reset_token = true
   config.default_confirm_success_url = 'http://localhost:9000/email-redirect'
+  config.default_password_reset_url = 'http://localhost:9000/change-password'
 end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -57,5 +57,6 @@ DeviseTokenAuth.setup do |config|
   # devise confirmable module. If you want to use devise confirmable module and
   # send email, set it to true. (This is a setting for compatibility)
   config.send_confirmation_email = true
+  config.require_client_password_reset_token = true
   config.default_confirm_success_url = 'http://localhost:9000/email-redirect'
 end

--- a/spec/integration/v1/authentication_spec.rb
+++ b/spec/integration/v1/authentication_spec.rb
@@ -233,4 +233,54 @@ describe 'Auth API', swagger_doc: 'v1/swagger.yaml' do
       end
     end
   end
+
+  path '/api/v1/auth/password' do
+    put 'Change password' do
+      tags 'Auth'
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          password: { type: :string },
+          password_confirmation: { type: :string }
+        },
+        required: %w[password password_confirmation]
+      }
+      let(:user) { { password: password, password_confirmation: password } }
+
+      response '200', 'password has been updated' do
+        include_context 'auth token'
+
+        run_test! do
+          expect(response.body).to include('Your password has been successfully updated')
+        end
+      end
+
+      response '422', "must fill out the fields password; doesn't match password" do
+        include_context 'auth token'
+
+        context 'not all fields' do
+          let(:user) { { password: password } }
+
+          run_test! do
+            expect(response.body).to include('You must fill out the fields')
+          end
+        end
+
+        context "password doesn't match" do
+          let(:user) { { password: password, password_confirmation: password*2 } }
+
+          run_test! do
+            expect(response.body).to include("doesn't match")
+          end
+        end
+      end
+
+      response '401', 'unauthorized' do
+        include_context 'auth token'
+        let(:"Access-Token") { 'not-token' }
+
+        run_test!
+      end
+    end
+  end
 end

--- a/spec/integration/v1/authentication_spec.rb
+++ b/spec/integration/v1/authentication_spec.rb
@@ -237,6 +237,7 @@ describe 'Auth API', swagger_doc: 'v1/swagger.yaml' do
   path '/api/v1/auth/password' do
     put 'Change password' do
       tags 'Auth'
+      description 'Change password'
       parameter name: :user, in: :body, schema: {
         type: :object,
         properties: {
@@ -280,6 +281,114 @@ describe 'Auth API', swagger_doc: 'v1/swagger.yaml' do
         let(:"Access-Token") { 'not-token' }
 
         run_test!
+      end
+    end
+  end
+
+  path '/api/v1/auth/password/' do
+    put 'Change password with reset_password_token' do
+      tags 'Auth'
+      description 'Set password that was reset'
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          password: { type: :string },
+          password_confirmation: { type: :string },
+          reset_password_token: { type: :string }
+        },
+        required: %w[password password_confirmation reset_password_token]
+      }
+      let!(:user_obj) { create(:user) }
+      let(:user) do
+        { password: password, password_confirmation: password,
+          reset_password_token: user_obj.send_reset_password_instructions }
+      end
+
+      security []
+
+      response '200', 'password has been updated' do
+        run_test! do
+          expect(response.body).to include('Your password has been successfully updated')
+        end
+      end
+
+      response '422', "must fill out the fields password; doesn't match password" do
+        context 'not all fields' do
+          let(:user) { { password: password, reset_password_token: user_obj.send_reset_password_instructions } }
+
+          run_test! do
+            expect(response.body).to include('You must fill out the fields')
+          end
+        end
+
+        context "password doesn't match" do
+          let(:user) do
+            { password: password, password_confirmation: password*2,
+              reset_password_token: user_obj.send_reset_password_instructions }
+          end
+          run_test! do
+            expect(response.body).to include("doesn't match")
+          end
+        end
+      end
+
+      response '401', 'unauthorized' do
+        let(:user) do
+          { password: password, password_confirmation: password,
+            reset_password_token: '' }
+        end
+
+        run_test!
+      end
+    end
+  end
+
+  path '/api/v1/auth/password/' do
+    post 'Send a  password reset confirmation email' do
+      tags 'Auth'
+      parameter name: :user, in: :body, schema: {
+        type: :object,
+        properties: {
+          email: { type: :string },
+          redirect_url: { type: :string }
+        },
+        required: %w[email redirect_url]
+      }
+      let!(:user_obj) { create(:user) }
+      let(:user) { { email: email, redirect_url: 'localhost:9000' } }
+
+      security []
+
+      response '200', 'email has been sent' do
+        run_test! do
+          expect(response.body).to include('An email has been sent')
+        end
+      end
+
+      response '404', 'invalid email' do
+        let(:email) { Faker::Internet.username }
+
+        run_test! do
+          expect(response.body).to include('Unable to find user')
+        end
+      end
+
+      response '401', 'missing field' do
+        context 'redirect_url' do
+          let(:user) { { email: email } }
+
+          run_test! do
+            expect(response.body).to include('Missing redirect URL')
+          end
+        end
+
+        context 'email' do
+          let(:user) { { redirect_url: 'localhost:9000' } }
+
+          run_test! do
+            expect(response.body).to include('You must provide an email address')
+          end
+        end
       end
     end
   end

--- a/spec/integration/v1/authentication_spec.rb
+++ b/spec/integration/v1/authentication_spec.rb
@@ -349,13 +349,12 @@ describe 'Auth API', swagger_doc: 'v1/swagger.yaml' do
       parameter name: :user, in: :body, schema: {
         type: :object,
         properties: {
-          email: { type: :string },
-          redirect_url: { type: :string }
+          email: { type: :string }
         },
-        required: %w[email redirect_url]
+        required: %w[email]
       }
       let!(:user_obj) { create(:user) }
-      let(:user) { { email: email, redirect_url: 'localhost:9000' } }
+      let(:user) { { email: email } }
 
       security []
 
@@ -373,21 +372,11 @@ describe 'Auth API', swagger_doc: 'v1/swagger.yaml' do
         end
       end
 
-      response '401', 'missing field' do
-        context 'redirect_url' do
-          let(:user) { { email: email } }
+      response '401', 'missing email' do
+        let(:user) {}
 
-          run_test! do
-            expect(response.body).to include('Missing redirect URL')
-          end
-        end
-
-        context 'email' do
-          let(:user) { { redirect_url: 'localhost:9000' } }
-
-          run_test! do
-            expect(response.body).to include('You must provide an email address')
-          end
+        run_test! do
+          expect(response.body).to include('You must provide an email address')
         end
       end
     end

--- a/spec/integration/v1/authentication_spec.rb
+++ b/spec/integration/v1/authentication_spec.rb
@@ -344,7 +344,7 @@ describe 'Auth API', swagger_doc: 'v1/swagger.yaml' do
   end
 
   path '/api/v1/auth/password/' do
-    post 'Send a  password reset confirmation email' do
+    post 'Send a password reset email' do
       tags 'Auth'
       parameter name: :user, in: :body, schema: {
         type: :object,

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -19,18 +19,18 @@ paths:
               example:
                 status: success
                 data:
-                  id: 4204
-                  username: jessia_medhurst#1
-                  email: freeman_berge@bayer-reinger.info
+                  id: 5536
+                  username: lanell#1
+                  email: dahlia.bode@beier-kiehn.io
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
                   coins: 0
                   fantasy_points: 0
-                  created_at: '2022-01-04T12:30:30.007Z'
-                  updated_at: '2022-01-04T12:30:30.007Z'
+                  created_at: '2022-01-04T17:04:47.656Z'
+                  updated_at: '2022-01-04T17:04:47.656Z'
                   provider: email
-                  uid: freeman_berge@bayer-reinger.info
+                  uid: dahlia.bode@beier-kiehn.io
                   allow_password_change: false
         '422':
           description: incorrect email or username; email and/or username has already
@@ -41,8 +41,8 @@ paths:
                 status: error
                 data:
                   id: 
-                  username: charise.mills#6
-                  email: gustavo
+                  username: christian_bode#6
+                  email: maisha.orn
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
@@ -87,7 +87,7 @@ paths:
             application/json:
               example:
                 status: success
-                message: Account with UID 'lemuel.fahey@mcclure.name' has been destroyed.
+                message: Account with UID 'lincoln_wiegand@emard.com' has been destroyed.
         '404':
           description: credentials are invalid
           content:
@@ -124,13 +124,13 @@ paths:
             application/json:
               example:
                 data:
-                  email: mack@oconnell.co
+                  email: chante_murazik@hammes-christiansen.name
                   email_validated: false
-                  id: 4209
+                  id: 5541
                   fantasy_points: 0
                   coins: 0
-                  uid: mack@oconnell.co
-                  username: bertram#9
+                  uid: chante_murazik@hammes-christiansen.name
+                  username: nestor#9
                   preferred_lang: ru_RU
                   avatar_id: 
                   provider: email
@@ -189,16 +189,16 @@ paths:
               example:
                 success: true
                 data:
-                  id: 4217
-                  username: leanna#17
-                  email: erich.heathcote@simonis.biz
+                  id: 5549
+                  username: louis.lang#17
+                  email: john.connelly@ortiz-murazik.co
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
                   coins: 0
                   fantasy_points: 0
                   provider: email
-                  uid: erich.heathcote@simonis.biz
+                  uid: john.connelly@ortiz-murazik.co
                   allow_password_change: false
         '401':
           description: credentials are invalid
@@ -222,8 +222,8 @@ paths:
             application/json:
               example:
                 success: true
-                message: An email has been sent to 'raymond@kihn-kemmer.name' containing
-                  instructions for confirming your account.
+                message: An email has been sent to 'frederick@trantow-murray.info'
+                  containing instructions for confirming your account.
         '404':
           description: email is invalid
           content:
@@ -231,7 +231,7 @@ paths:
               example:
                 success: false
                 errors:
-                - Unable to find user with email 'korey.haag@langosh.net'.
+                - Unable to find user with email 'merlin@gerhold-lowe.io'.
       requestBody:
         content:
           application/json:
@@ -247,6 +247,7 @@ paths:
       summary: Change password
       tags:
       - Auth
+      description: Change password
       parameters: []
       responses:
         '200':
@@ -256,17 +257,17 @@ paths:
               example:
                 success: true
                 data:
-                  email: judi@howell.biz
+                  email: benito_paucek@kohler.net
                   email_validated: false
-                  id: 4221
+                  id: 5553
                   fantasy_points: 0
                   coins: 0
-                  uid: judi@howell.biz
-                  username: bertram#21
+                  uid: benito_paucek@kohler.net
+                  username: ray.gusikowski#21
                   preferred_lang: ru_RU
                   avatar_id: 
-                  created_at: '2022-01-04T12:30:35.516Z'
-                  updated_at: '2022-01-04T12:30:35.723Z'
+                  created_at: '2022-01-04T17:04:53.260Z'
+                  updated_at: '2022-01-04T17:04:53.466Z'
                   provider: email
                   allow_password_change: false
                 message: Your password has been successfully updated.
@@ -302,6 +303,115 @@ paths:
               required:
               - password
               - password_confirmation
+  "/api/v1/auth/password/":
+    put:
+      summary: Change password with reset_password_token
+      tags:
+      - Auth
+      description: Set password that was reset
+      parameters: []
+      security: []
+      responses:
+        '200':
+          description: password has been updated
+          content:
+            application/json:
+              example:
+                success: true
+                data:
+                  email: lorenza@fay-mcdermott.name
+                  email_validated: false
+                  id: 5557
+                  fantasy_points: 0
+                  coins: 0
+                  uid: lorenza@fay-mcdermott.name
+                  username: louise#25
+                  preferred_lang: ru_RU
+                  avatar_id: 
+                  created_at: '2022-01-04T17:04:54.517Z'
+                  updated_at: '2022-01-04T17:04:54.786Z'
+                  provider: email
+                  allow_password_change: false
+                message: Your password has been successfully updated.
+        '422':
+          description: must fill out the fields password; doesn't match password
+          content:
+            application/json:
+              example:
+                success: false
+                errors:
+                  password_confirmation:
+                  - doesn't match Password
+                  full_messages:
+                  - Password confirmation doesn't match Password
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                success: false
+                errors:
+                - Unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                password_confirmation:
+                  type: string
+                reset_password_token:
+                  type: string
+              required:
+              - password
+              - password_confirmation
+              - reset_password_token
+    post:
+      summary: Send a  password reset confirmation email
+      tags:
+      - Auth
+      parameters: []
+      security: []
+      responses:
+        '200':
+          description: email has been sent
+          content:
+            application/json:
+              example:
+                success: true
+                message: An email has been sent to 'chiquita_rutherford@ohara.name'
+                  containing instructions for resetting your password.
+        '404':
+          description: invalid email
+          content:
+            application/json:
+              example:
+                success: false
+                errors:
+                - Unable to find user with email 'johnny.price'.
+        '401':
+          description: missing field
+          content:
+            application/json:
+              example:
+                success: false
+                errors:
+                - You must provide an email address.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                redirect_url:
+                  type: string
+              required:
+              - email
+              - redirect_url
 consumes:
 - application/json
 produces:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -19,18 +19,18 @@ paths:
               example:
                 status: success
                 data:
-                  id: 5536
-                  username: lanell#1
-                  email: dahlia.bode@beier-kiehn.io
+                  id: 5593
+                  username: darwin#1
+                  email: german@donnelly.co
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
                   coins: 0
                   fantasy_points: 0
-                  created_at: '2022-01-04T17:04:47.656Z'
-                  updated_at: '2022-01-04T17:04:47.656Z'
+                  created_at: '2022-01-05T09:46:33.960Z'
+                  updated_at: '2022-01-05T09:46:33.960Z'
                   provider: email
-                  uid: dahlia.bode@beier-kiehn.io
+                  uid: german@donnelly.co
                   allow_password_change: false
         '422':
           description: incorrect email or username; email and/or username has already
@@ -41,8 +41,8 @@ paths:
                 status: error
                 data:
                   id: 
-                  username: christian_bode#6
-                  email: maisha.orn
+                  username: darwin.mosciski#6
+                  email: donnell.corkery
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
@@ -87,7 +87,7 @@ paths:
             application/json:
               example:
                 status: success
-                message: Account with UID 'lincoln_wiegand@emard.com' has been destroyed.
+                message: Account with UID 'vernia@grant-durgan.biz' has been destroyed.
         '404':
           description: credentials are invalid
           content:
@@ -124,13 +124,13 @@ paths:
             application/json:
               example:
                 data:
-                  email: chante_murazik@hammes-christiansen.name
+                  email: graig.reichel@weimann.net
                   email_validated: false
-                  id: 5541
+                  id: 5598
                   fantasy_points: 0
                   coins: 0
-                  uid: chante_murazik@hammes-christiansen.name
-                  username: nestor#9
+                  uid: graig.reichel@weimann.net
+                  username: lacresha_frami#9
                   preferred_lang: ru_RU
                   avatar_id: 
                   provider: email
@@ -189,16 +189,16 @@ paths:
               example:
                 success: true
                 data:
-                  id: 5549
-                  username: louis.lang#17
-                  email: john.connelly@ortiz-murazik.co
+                  id: 5606
+                  username: jay_nolan#17
+                  email: erlinda_mraz@wolf.name
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
                   coins: 0
                   fantasy_points: 0
                   provider: email
-                  uid: john.connelly@ortiz-murazik.co
+                  uid: erlinda_mraz@wolf.name
                   allow_password_change: false
         '401':
           description: credentials are invalid
@@ -222,7 +222,7 @@ paths:
             application/json:
               example:
                 success: true
-                message: An email has been sent to 'frederick@trantow-murray.info'
+                message: An email has been sent to 'oren_ward@hilll-hartmann.biz'
                   containing instructions for confirming your account.
         '404':
           description: email is invalid
@@ -231,7 +231,7 @@ paths:
               example:
                 success: false
                 errors:
-                - Unable to find user with email 'merlin@gerhold-lowe.io'.
+                - Unable to find user with email 'wayne_rau@rice-keeling.net'.
       requestBody:
         content:
           application/json:
@@ -257,17 +257,17 @@ paths:
               example:
                 success: true
                 data:
-                  email: benito_paucek@kohler.net
+                  email: holly.haag@bernier.biz
                   email_validated: false
-                  id: 5553
+                  id: 5610
                   fantasy_points: 0
                   coins: 0
-                  uid: benito_paucek@kohler.net
-                  username: ray.gusikowski#21
+                  uid: holly.haag@bernier.biz
+                  username: jerrod.emmerich#21
                   preferred_lang: ru_RU
                   avatar_id: 
-                  created_at: '2022-01-04T17:04:53.260Z'
-                  updated_at: '2022-01-04T17:04:53.466Z'
+                  created_at: '2022-01-05T09:46:41.039Z'
+                  updated_at: '2022-01-05T09:46:41.267Z'
                   provider: email
                   allow_password_change: false
                 message: Your password has been successfully updated.
@@ -319,17 +319,17 @@ paths:
               example:
                 success: true
                 data:
-                  email: lorenza@fay-mcdermott.name
+                  email: lyn.padberg@stokes.org
                   email_validated: false
-                  id: 5557
+                  id: 5614
                   fantasy_points: 0
                   coins: 0
-                  uid: lorenza@fay-mcdermott.name
-                  username: louise#25
+                  uid: lyn.padberg@stokes.org
+                  username: divina.leffler#25
                   preferred_lang: ru_RU
                   avatar_id: 
-                  created_at: '2022-01-04T17:04:54.517Z'
-                  updated_at: '2022-01-04T17:04:54.786Z'
+                  created_at: '2022-01-05T09:46:42.376Z'
+                  updated_at: '2022-01-05T09:46:42.654Z'
                   provider: email
                   allow_password_change: false
                 message: Your password has been successfully updated.
@@ -381,7 +381,7 @@ paths:
             application/json:
               example:
                 success: true
-                message: An email has been sent to 'chiquita_rutherford@ohara.name'
+                message: An email has been sent to 'valentine_streich@cremin-wintheiser.biz'
                   containing instructions for resetting your password.
         '404':
           description: invalid email
@@ -390,9 +390,9 @@ paths:
               example:
                 success: false
                 errors:
-                - Unable to find user with email 'johnny.price'.
+                - Unable to find user with email 'florrie.mertz'.
         '401':
-          description: missing field
+          description: missing email
           content:
             application/json:
               example:
@@ -407,11 +407,8 @@ paths:
               properties:
                 email:
                   type: string
-                redirect_url:
-                  type: string
               required:
               - email
-              - redirect_url
 consumes:
 - application/json
 produces:

--- a/swagger/v1/swagger.yaml
+++ b/swagger/v1/swagger.yaml
@@ -19,18 +19,18 @@ paths:
               example:
                 status: success
                 data:
-                  id: 1
-                  username: margret_kassulke#1
-                  email: glenna.mcglynn@gibson.info
+                  id: 4204
+                  username: jessia_medhurst#1
+                  email: freeman_berge@bayer-reinger.info
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
                   coins: 0
                   fantasy_points: 0
-                  created_at: '2022-01-04T10:53:38.966Z'
-                  updated_at: '2022-01-04T10:53:38.966Z'
+                  created_at: '2022-01-04T12:30:30.007Z'
+                  updated_at: '2022-01-04T12:30:30.007Z'
                   provider: email
-                  uid: glenna.mcglynn@gibson.info
+                  uid: freeman_berge@bayer-reinger.info
                   allow_password_change: false
         '422':
           description: incorrect email or username; email and/or username has already
@@ -41,8 +41,8 @@ paths:
                 status: error
                 data:
                   id: 
-                  username: kenneth_vonrueden#6
-                  email: danyell_marks
+                  username: charise.mills#6
+                  email: gustavo
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
@@ -87,7 +87,7 @@ paths:
             application/json:
               example:
                 status: success
-                message: Account with UID 'jennifer_grady@kris.name' has been destroyed.
+                message: Account with UID 'lemuel.fahey@mcclure.name' has been destroyed.
         '404':
           description: credentials are invalid
           content:
@@ -124,13 +124,13 @@ paths:
             application/json:
               example:
                 data:
-                  email: arthur@schuster.com
+                  email: mack@oconnell.co
                   email_validated: false
-                  id: 6
+                  id: 4209
                   fantasy_points: 0
                   coins: 0
-                  uid: arthur@schuster.com
-                  username: armandina.batz#9
+                  uid: mack@oconnell.co
+                  username: bertram#9
                   preferred_lang: ru_RU
                   avatar_id: 
                   provider: email
@@ -189,16 +189,16 @@ paths:
               example:
                 success: true
                 data:
-                  id: 14
-                  username: chong#17
-                  email: angelika@flatley.info
+                  id: 4217
+                  username: leanna#17
+                  email: erich.heathcote@simonis.biz
                   email_validated: false
                   preferred_lang: ru_RU
                   avatar_id: 
                   coins: 0
                   fantasy_points: 0
                   provider: email
-                  uid: angelika@flatley.info
+                  uid: erich.heathcote@simonis.biz
                   allow_password_change: false
         '401':
           description: credentials are invalid
@@ -222,8 +222,8 @@ paths:
             application/json:
               example:
                 success: true
-                message: An email has been sent to 'maria@borer.net' containing instructions
-                  for confirming your account.
+                message: An email has been sent to 'raymond@kihn-kemmer.name' containing
+                  instructions for confirming your account.
         '404':
           description: email is invalid
           content:
@@ -231,7 +231,7 @@ paths:
               example:
                 success: false
                 errors:
-                - Unable to find user with email 'mireille@weissnat.biz'.
+                - Unable to find user with email 'korey.haag@langosh.net'.
       requestBody:
         content:
           application/json:
@@ -242,6 +242,66 @@ paths:
                   type: string
               required:
               - email
+  "/api/v1/auth/password":
+    put:
+      summary: Change password
+      tags:
+      - Auth
+      parameters: []
+      responses:
+        '200':
+          description: password has been updated
+          content:
+            application/json:
+              example:
+                success: true
+                data:
+                  email: judi@howell.biz
+                  email_validated: false
+                  id: 4221
+                  fantasy_points: 0
+                  coins: 0
+                  uid: judi@howell.biz
+                  username: bertram#21
+                  preferred_lang: ru_RU
+                  avatar_id: 
+                  created_at: '2022-01-04T12:30:35.516Z'
+                  updated_at: '2022-01-04T12:30:35.723Z'
+                  provider: email
+                  allow_password_change: false
+                message: Your password has been successfully updated.
+        '422':
+          description: must fill out the fields password; doesn't match password
+          content:
+            application/json:
+              example:
+                success: false
+                errors:
+                  password_confirmation:
+                  - doesn't match Password
+                  full_messages:
+                  - Password confirmation doesn't match Password
+        '401':
+          description: unauthorized
+          content:
+            application/json:
+              example:
+                success: false
+                errors:
+                - Unauthorized
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                password:
+                  type: string
+                password_confirmation:
+                  type: string
+              required:
+              - password
+              - password_confirmation
 consumes:
 - application/json
 produces:


### PR DESCRIPTION
Добавил тесты на изменение пароля, установку пароля после сброса.
Запрос PUT /auth/password может быть отправлен с auth_headers(пользователь авторизован), либо с reset_password_token полученным при перенаправлении из ссылки в письме.
Флоу сброса пароля таков: 
1. User fills out password reset request form (this POST /auth/password)
2. User is sent an email
3. User clicks confirmation link (this GET /auth/password/edit)
4. Link leads to the client to the redirect_url with a reset_password_token
5. User submits password along with reset_password_token (this PUT /auth/password)
6. User is now authorized and has a new password