### PR TITLE
Fix error message on resetting password

### DIFF
--- a/app/controllers/api/v1/auth/passwords_controller.rb
+++ b/app/controllers/api/v1/auth/passwords_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    module Auth
+      # Not to show users that there is no such email in the database
+      class PasswordsController < DeviseTokenAuth::PasswordsController
+        def create
+          return render_create_error_missing_email unless resource_params[:email]
+
+          @email = get_case_insensitive_field_from_resource_params(:email)
+          @resource = find_resource(:uid, @email)
+
+          if @resource
+            yield @resource if block_given?
+            @resource.send_reset_password_instructions(
+              email: @email,
+              provider: 'email',
+              redirect_url: @redirect_url,
+              client_config: params[:config_name]
+            )
+
+            if @resource.errors.empty?
+              render_create_success
+            else
+              render_create_error @resource.errors
+            end
+          else
+            render_create_success
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for 'User', at: 'auth', controllers: {
         registrations: 'api/v1/auth/registration',
         sessions: 'api/v1/auth/sessions',
-        confirmations: 'api/v1/auth/confirmations'
+        confirmations: 'api/v1/auth/confirmations',
+        passwords: 'api/v1/auth/passwords'
       }
 
       namespace :users do

--- a/spec/integration/v1/authentication_spec.rb
+++ b/spec/integration/v1/authentication_spec.rb
@@ -364,14 +364,6 @@ describe 'Auth API', swagger_doc: 'v1/swagger.yaml' do
         end
       end
 
-      response '404', 'invalid email' do
-        let(:email) { Faker::Internet.username }
-
-        run_test! do
-          expect(response.body).to include('Unable to find user')
-        end
-      end
-
       response '401', 'missing email' do
         let(:user) {}
 


### PR DESCRIPTION
Мини PR, изменяющий поведение сброса пароля: если юсер в "забыли пароль" вводит отсутствующий в базе email, он увидит сообщение об успехе, но письмо естественно не отправится.